### PR TITLE
Make file download work again

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -258,7 +258,7 @@ class repository_github extends repository {
         $fp = fopen($path, 'w');
         $c = new curl();
         $c->setopt(array('CURLOPT_FOLLOWLOCATION' => true, 'CURLOPT_MAXREDIRS' => 3));
-        $result = $c->download(array(array('url' => $url, 'file'=> $fp)));
+        $result = $c->download_one($url, null, ['file' => $fp]);
 
         // Close file handler.
         fclose($fp);


### PR DESCRIPTION
For some (unknown yet) reason, the curl::download() function, which in
turn uses curl_multi_exec(), has stopped working for Github. It turns
out the simpler download_one() works well and is enough in this case.

Fix issue #9 